### PR TITLE
Address Sonar issues

### DIFF
--- a/src/client/javascripts/teamsheet-review.ts
+++ b/src/client/javascripts/teamsheet-review.ts
@@ -10,32 +10,30 @@ interface MatchState {
 const STORAGE_KEY = 'teamsheet-review-state'
 const matchStates: Map<string, MatchState> = new Map()
 
+function resolveInitialState (match: any, saved: Record<string, MatchState> | null, key: string): MatchState {
+  const isKeeper = match.position === 'Goalkeeper'
+
+  if (saved?.[key]) {
+    return saved[key]
+  }
+  if (match.category === 'confident' && match.bestMatch) {
+    return {
+      resolved: true,
+      playerId: isKeeper ? null : match.bestMatch.playerId,
+      teamId: isKeeper ? match.bestMatch.teamId : null,
+      isKeeper,
+    }
+  }
+  return { resolved: false, playerId: null, teamId: null, isKeeper }
+}
+
 function initStates () {
   const saved = loadFromStorage()
 
   for (const team of previewData.teams) {
     for (let i = 0; i < team.matches.length; i++) {
-      const match = team.matches[i]
       const key = `${team.managerId}-${i}`
-      const isKeeper = match.position === 'Goalkeeper'
-
-      if (saved && saved[key]) {
-        matchStates.set(key, saved[key])
-      } else if (match.category === 'confident' && match.bestMatch) {
-        matchStates.set(key, {
-          resolved: true,
-          playerId: isKeeper ? null : match.bestMatch.playerId,
-          teamId: isKeeper ? match.bestMatch.teamId : null,
-          isKeeper,
-        })
-      } else {
-        matchStates.set(key, {
-          resolved: false,
-          playerId: null,
-          teamId: null,
-          isKeeper,
-        })
-      }
+      matchStates.set(key, resolveInitialState(team.matches[i], saved, key))
     }
   }
 
@@ -49,7 +47,7 @@ function saveToStorage () {
     const obj: Record<string, MatchState> = {}
     matchStates.forEach((state, key) => { obj[key] = state })
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(obj))
-  } catch (_) {}
+  } catch { /* expected: sessionStorage may be unavailable */ }
 }
 
 function loadFromStorage (): Record<string, MatchState> | null {
@@ -57,20 +55,20 @@ function loadFromStorage (): Record<string, MatchState> | null {
     const raw = sessionStorage.getItem(STORAGE_KEY)
     if (!raw) { return null }
     return JSON.parse(raw)
-  } catch (_) {
+  } catch { /* expected: sessionStorage may be unavailable */
     return null
   }
 }
 
 function clearStorage () {
-  try { sessionStorage.removeItem(STORAGE_KEY) } catch (_) {}
+  try { sessionStorage.removeItem(STORAGE_KEY) } catch { /* expected: sessionStorage may be unavailable */ }
 }
 
 function restoreResolvedRows () {
   $('.match-row').each(function () {
     const key = getMatchKey($(this))
     const state = matchStates.get(key)
-    if (state && state.resolved) {
+    if (state?.resolved) {
       markRowResolved($(this), 'Resolved')
     }
   })
@@ -257,7 +255,7 @@ $(function () {
       url: '/teamsheet/player/create',
       type: 'POST',
       contentType: 'application/json',
-      data: JSON.stringify({ firstName, lastName, position, teamId: parseInt(teamId) }),
+      data: JSON.stringify({ firstName, lastName, position, teamId: Number.parseInt(teamId) }),
       success (data: any) {
         const key = getMatchKey($row)
         const state = matchStates.get(key)
@@ -337,7 +335,7 @@ $(function () {
       url: '/teamsheet/player/transfer',
       type: 'POST',
       contentType: 'application/json',
-      data: JSON.stringify({ playerId, teamId: parseInt(teamId) }),
+      data: JSON.stringify({ playerId, teamId: Number.parseInt(teamId) }),
       success () {
         const key = getMatchKey($row)
         const state = matchStates.get(key)
@@ -401,7 +399,7 @@ $(function () {
         const key = `${team.managerId}-${i}`
         const state = matchStates.get(key)
 
-        if (!state || !state.resolved) { continue }
+        if (!state?.resolved) { continue }
 
         if (state.isKeeper && state.teamId) {
           keeperAssignments.push({

--- a/src/routes/results.ts
+++ b/src/routes/results.ts
@@ -21,7 +21,7 @@ const routes: ServerRoute[] = [{
       },
     },
     handler: async (request, h) => {
-      const gameweekId = (request.query as Record<string, unknown>)?.gameweekId || 0
+      const gameweekId = String((request.query as Record<string, unknown>)?.gameweekId || 0)
       const results = await get(`/results?gameweekId=${gameweekId}`, request)
       const gameweeks = await get('/gameweeks?completed=true', request)
       return h.view('results', { results, gameweeks })

--- a/src/session/redis-client.ts
+++ b/src/session/redis-client.ts
@@ -29,7 +29,7 @@ export async function connect (): Promise<void> {
 
 export async function disconnect (): Promise<void> {
   if (client.isOpen) {
-    await client.disconnect()
+    await client.quit()
   }
 }
 

--- a/test/integration/player-refresh.test.ts
+++ b/test/integration/player-refresh.test.ts
@@ -25,7 +25,7 @@ describe('refreshing player list', () => {
     const result = await refreshPlayers(TEST_FILE) as { success: boolean }
 
     expect(result.success).toBeTruthy()
-    expect(mockPost.mock.calls.length).toBe(1)
+    expect(mockPost.mock.calls).toHaveLength(1)
   })
 
   test('should return failure if list invalid', async () => {
@@ -34,7 +34,7 @@ describe('refreshing player list', () => {
     const result = await refreshPlayers(TEST_FILE) as { success: boolean }
 
     expect(result.success).toBeFalsy()
-    expect(mockPost.mock.calls.length).toBe(1)
+    expect(mockPost.mock.calls).toHaveLength(1)
   })
 
   test('request should be made to refresh endpoint', async () => {
@@ -50,7 +50,7 @@ describe('refreshing player list', () => {
 
     await refreshPlayers(TEST_FILE)
 
-    expect(mockPost.mock.calls[0]![1].players.length).toBe(2176)
+    expect(mockPost.mock.calls[0]![1].players).toHaveLength(2176)
   })
 
   test('request should include example player', async () => {
@@ -67,7 +67,7 @@ describe('refreshing player list', () => {
     const result = await refreshPlayers(TEST_FILE) as { success: boolean; unmappedPlayers: unknown[] }
 
     expect(result.success).toBeFalsy()
-    expect(result.unmappedPlayers.length).toBe(1)
+    expect(result.unmappedPlayers).toHaveLength(1)
     expect(result.unmappedPlayers).toContainEqual({ firstName: 'Adebayo', lastName: 'Akinfenwa', position: 'FWD', team: 'Wycombe' })
   })
 })

--- a/test/integration/teamsheet-refresh.test.ts
+++ b/test/integration/teamsheet-refresh.test.ts
@@ -18,32 +18,32 @@ describe('parsing teamsheet', () => {
     const result = await parseTeamsheet(TEST_FILE)
 
     expect(result).not.toBeNull()
-    expect(result!.length).toBe(13)
+    expect(result!).toHaveLength(13)
   })
 
   test('should include all managers', async () => {
     const result = await parseTeamsheet(TEST_FILE) as { manager: string }[]
 
-    expect(result.filter(x => x.manager === 'John').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Lee').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Scott').length).toBe(1)
-    expect(result.filter(x => x.manager === 'David').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Billy').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Bob').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Conor').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Daz').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Rob').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Tucker').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Tommy/Pete').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Michael').length).toBe(1)
-    expect(result.filter(x => x.manager === 'Ben').length).toBe(1)
+    expect(result.filter(x => x.manager === 'John')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Lee')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Scott')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'David')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Billy')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Bob')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Conor')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Daz')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Rob')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Tucker')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Tommy/Pete')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Michael')).toHaveLength(1)
+    expect(result.filter(x => x.manager === 'Ben')).toHaveLength(1)
   })
 
   test('should include 15 players per team', async () => {
     const result = await parseTeamsheet(TEST_FILE) as { players: unknown[] }[]
 
     for (const team of result) {
-      expect(team.players.length).toBe(15)
+      expect(team.players).toHaveLength(15)
     }
   })
 


### PR DESCRIPTION
## Summary
- Reduce cognitive complexity of `initStates` by extracting `resolveInitialState` helper (S3776)
- Use optional chaining throughout `teamsheet-review.ts` (S6582)
- Add comments to intentional empty catch blocks for sessionStorage (S2486)
- Use `Number.parseInt` over global `parseInt` (S7773)
- Coerce `gameweekId` to string to prevent `[object Object]` in URL (S6551)
- Replace `.length).toBe()` with `.toHaveLength()` in test assertions (S5906)
- Use `client.quit()` instead of deprecated `client.disconnect()` (S1874)

## Test plan
- [x] All 55 tests pass