### PR TITLE
Enhance player upload

### DIFF
--- a/src/client/javascripts/player-refresh-review.ts
+++ b/src/client/javascripts/player-refresh-review.ts
@@ -1,0 +1,46 @@
+const previewData = JSON.parse($('#preview-data').val() as string)
+
+function checkAllResolved (): void {
+  const allResolved = $('.team-select').toArray().every(
+    (el) => $(el).val() !== ''
+  )
+  $('#confirm-btn').prop('disabled', !allResolved)
+}
+
+$(function () {
+  $(document).on('change', '.team-select', checkAllResolved)
+
+  $('#confirm-btn').on('click', function () {
+    const $btn = $(this)
+    $btn.prop('disabled', true).text('Saving...')
+
+    const allPlayers = [...previewData.mappedPlayers]
+
+    previewData.unmappedTeams.forEach((item: any, index: number) => {
+      const teamId = Number($(`select[data-index="${index}"]`).val())
+      for (const player of item.players) {
+        allPlayers.push({
+          firstName: player.firstName,
+          lastName: player.lastName,
+          position: player.position,
+          teamId,
+        })
+      }
+    })
+
+    $.ajax({
+      url: '/league/refresh/players/confirm',
+      type: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({ players: allPlayers }),
+      success () {
+        window.location.href = '/league/players'
+      },
+      error () {
+        $btn.prop('disabled', false).text('Confirm and Save All Players')
+        $('#status-message').text('Failed to save players. Please try again.')
+        $('#review-status').show()
+      },
+    })
+  })
+})

--- a/src/refresh/players/refresh.ts
+++ b/src/refresh/players/refresh.ts
@@ -16,5 +16,5 @@ export async function refreshPlayers (path: string, token?: Request): Promise<un
   const players = XLSX.utils.sheet_to_json(worksheet) as Parameters<typeof mapPlayer>[0][]
   await unlink(path)
   const mappedPlayers = players.map(mapPlayer)
-  return post('/league/players/refresh', { players: mappedPlayers }, token)
+  return post('/league/players/refresh/preview', { players: mappedPlayers }, token)
 }

--- a/src/routes/league/refresh.ts
+++ b/src/routes/league/refresh.ts
@@ -1,6 +1,8 @@
 import type { ServerRoute } from '@hapi/hapi'
 import Joi from 'joi'
 import { refreshPlayers } from '../../refresh/players/refresh.ts'
+import { get } from '../../api/get.ts'
+import { post } from '../../api/post.ts'
 
 const routes: ServerRoute[] = [{
   method: 'GET',
@@ -42,19 +44,48 @@ const routes: ServerRoute[] = [{
     },
     handler: async (request, h) => {
       const payload = request.payload as { playerFile: { path: string } }
-      const response = await refreshPlayers(payload.playerFile.path, request) as { success: boolean; unmappedPlayers?: unknown[] }
-      if (response.success) {
+      const response = await refreshPlayers(payload.playerFile.path, request) as { mappedPlayers: any[]; unmappedTeams: any[] }
+
+      if (!response.mappedPlayers && !response.unmappedTeams) {
+        return h.view('league/refresh', { message: 'Invalid players list' })
+      }
+
+      if (!response.unmappedTeams.length) {
+        await post('/league/players/refresh/confirm', { players: response.mappedPlayers }, request)
         return h.redirect('/league/players')
       }
 
-      if (response.unmappedPlayers) {
-        return h.view('league/refresh', {
-          message: 'Some players could not be mapped',
-          unmappedPlayers: response.unmappedPlayers,
-        })
-      }
-
-      return h.view('league/refresh', { message: 'Invalid players list' })
+      const teams = await get('/league/teams', request) as any[]
+      return h.view('league/refresh-review', {
+        mappedPlayers: response.mappedPlayers,
+        unmappedTeams: response.unmappedTeams,
+        teams,
+        previewJson: JSON.stringify(response),
+      })
+    },
+  },
+}, {
+  method: 'POST',
+  path: '/league/refresh/players/confirm',
+  options: {
+    auth: { strategy: 'session', scope: ['admin'] },
+    plugins: { crumb: false },
+    validate: {
+      payload: Joi.object({
+        players: Joi.array().items(Joi.object({
+          firstName: Joi.string().allow('', null),
+          lastName: Joi.string().allow('', null),
+          position: Joi.string().required(),
+          teamId: Joi.number().integer().required(),
+        })),
+      }),
+      failAction: async (_request, h, _error) => {
+        return h.response({ success: false, message: 'Invalid payload' }).code(400).takeover()
+      },
+    },
+    handler: async (request, h) => {
+      const result = await post('/league/players/refresh/confirm', request.payload, request) as object
+      return h.response(result)
     },
   },
 }]

--- a/src/views/league/refresh-review.njk
+++ b/src/views/league/refresh-review.njk
@@ -1,0 +1,48 @@
+{% extends '_layout.njk' %}
+
+{% block content %}
+  <h2>Player Refresh - Resolve Unmatched Teams</h2>
+
+  <div class="alert alert-info">
+    <strong>{{ mappedPlayers.length }}</strong> players matched automatically.
+    <strong>{{ unmappedTeams.length }}</strong> team name(s) need manual resolution.
+  </div>
+
+  <div id="review-status" class="alert alert-danger" style="display: none;">
+    <span id="status-message"></span>
+  </div>
+
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Unmatched Team Name</th>
+        <th>Players</th>
+        <th>Assign To Team</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in unmappedTeams %}
+        <tr>
+          <td>{{ item.team }}</td>
+          <td>{{ item.players.length }}</td>
+          <td>
+            <select class="form-control team-select" data-index="{{ loop.index0 }}">
+              <option value="">-- Select team --</option>
+              {% for team in teams %}
+                <option value="{{ team.teamId }}">{{ team.name }}</option>
+              {% endfor %}
+            </select>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <button id="confirm-btn" class="btn btn-primary" disabled>Confirm and Save All Players</button>
+
+  <textarea id="preview-data" style="display:none;">{{ previewJson }}</textarea>
+{% endblock %}
+
+{% block bodyEnd %}
+  <script src="{{ asset('javascripts/player-refresh-review.js') }}"></script>
+{% endblock %}

--- a/test/integration/player-refresh.test.ts
+++ b/test/integration/player-refresh.test.ts
@@ -19,34 +19,35 @@ describe('refreshing player list', () => {
     fs.copyFileSync(BASE_TEST_FILE, TEST_FILE)
   })
 
-  test('should return success if list valid', async () => {
-    mockPost.mockResolvedValue({ success: true })
+  test('should return preview response with mapped players', async () => {
+    mockPost.mockResolvedValue({ mappedPlayers: [{ firstName: 'Ian', lastName: 'Henderson', position: 'Forward', teamId: 1 }], unmappedTeams: [] })
 
-    const result = await refreshPlayers(TEST_FILE) as { success: boolean }
+    const result = await refreshPlayers(TEST_FILE) as { mappedPlayers: any[]; unmappedTeams: any[] }
 
-    expect(result.success).toBeTruthy()
+    expect(result.mappedPlayers).toHaveLength(1)
+    expect(result.unmappedTeams).toHaveLength(0)
     expect(mockPost.mock.calls).toHaveLength(1)
   })
 
-  test('should return failure if list invalid', async () => {
-    mockPost.mockResolvedValue({ success: false })
+  test('should return preview response with unmapped teams', async () => {
+    mockPost.mockResolvedValue({ mappedPlayers: [], unmappedTeams: [{ team: 'Wycombe', players: [{ firstName: 'Adebayo', lastName: 'Akinfenwa', position: 'FWD' }] }] })
 
-    const result = await refreshPlayers(TEST_FILE) as { success: boolean }
+    const result = await refreshPlayers(TEST_FILE) as { mappedPlayers: any[]; unmappedTeams: any[] }
 
-    expect(result.success).toBeFalsy()
-    expect(mockPost.mock.calls).toHaveLength(1)
+    expect(result.unmappedTeams).toHaveLength(1)
+    expect(result.unmappedTeams[0].team).toBe('Wycombe')
   })
 
-  test('request should be made to refresh endpoint', async () => {
-    mockPost.mockResolvedValue({ success: true })
+  test('request should be made to preview endpoint', async () => {
+    mockPost.mockResolvedValue({ mappedPlayers: [], unmappedTeams: [] })
 
     await refreshPlayers(TEST_FILE)
 
-    expect(mockPost.mock.calls[0]![0]).toBe('/league/players/refresh')
+    expect(mockPost.mock.calls[0]![0]).toBe('/league/players/refresh/preview')
   })
 
   test('request should include all players', async () => {
-    mockPost.mockResolvedValue({ success: true })
+    mockPost.mockResolvedValue({ mappedPlayers: [], unmappedTeams: [] })
 
     await refreshPlayers(TEST_FILE)
 
@@ -54,20 +55,10 @@ describe('refreshing player list', () => {
   })
 
   test('request should include example player', async () => {
-    mockPost.mockResolvedValue({ success: true })
+    mockPost.mockResolvedValue({ mappedPlayers: [], unmappedTeams: [] })
 
     await refreshPlayers(TEST_FILE)
 
     expect(mockPost.mock.calls[0]![1].players).toContainEqual({ firstName: 'Ian', lastName: 'Henderson', position: 'FWD', team: 'Rochdale' })
-  })
-
-  test('should return failure should include unmapped players', async () => {
-    mockPost.mockResolvedValue({ success: false, unmappedPlayers: [{ firstName: 'Adebayo', lastName: 'Akinfenwa', position: 'FWD', team: 'Wycombe' }] })
-
-    const result = await refreshPlayers(TEST_FILE) as { success: boolean; unmappedPlayers: unknown[] }
-
-    expect(result.success).toBeFalsy()
-    expect(result.unmappedPlayers).toHaveLength(1)
-    expect(result.unmappedPlayers).toContainEqual({ firstName: 'Adebayo', lastName: 'Akinfenwa', position: 'FWD', team: 'Wycombe' })
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig(({ mode }) => ({
         'teamsheet-review': path.resolve(dirname, 'src/client/javascripts/teamsheet-review.ts'),
         'goal-report': path.resolve(dirname, 'src/client/javascripts/goal-report.ts'),
         live: path.resolve(dirname, 'src/client/javascripts/live.ts'),
+        'player-refresh-review': path.resolve(dirname, 'src/client/javascripts/player-refresh-review.ts'),
       },
       output: {
         entryFileNames: mode === 'production'


### PR DESCRIPTION
## Summary
- Add review page with team resolution UI when uploaded players have unmatched team names
- Each unique unmatched team name gets a dropdown to assign to an existing team
- On confirmation, all players (auto-matched + manually resolved) are saved together
- Clean files with no mismatches auto-confirm as before (no UX change for happy path)
