### PR TITLE
Refine matchday

### DIFF
--- a/src/client/javascripts/live.ts
+++ b/src/client/javascripts/live.ts
@@ -1,86 +1,198 @@
+interface Scorer {
+  playerId: number
+  name: string
+  goals: number
+}
+
+interface LiveScore {
+  managerId: number
+  manager: string
+  goals: number
+  conceded: number
+  result: string
+  scorers: Scorer[]
+}
+
+interface GoalEvent {
+  id: string
+  minute: number | null
+  scorer?: { name: string }
+  scoringTeam?: { name: string }
+  potentialGoalFor?: { managerId: number; playerId: number; player: string }
+  potentialConcedingFor?: { managerId: number }
+}
+
+const MAX_FEED_ROWS = 50
+
 $(function () {
   const liveData = JSON.parse($('#live-data').text() || '{}')
-  const videprinterStreamUrl: string = liveData.videprinterStreamUrl || ''
-  const managerScores: Record<number, { goals: number; conceded: number }> = {}
-  for (const manager of liveData.managers || []) {
-    managerScores[manager.managerId] = { goals: 0, conceded: 0 }
+  const streamUrl: string = liveData.streamUrl || ''
+  const historyUrl: string = liveData.historyUrl || ''
+
+  const scores = new Map<number, LiveScore>()
+  for (const score of (liveData.scores || []) as LiveScore[]) {
+    scores.set(score.managerId, score)
   }
+
+  const countedEventIds = new Set<string>()
 
   const $status = $('#connection-status')
   const $feed = $('#goal-feed')
+  const $feedEmpty = $('#goal-feed-empty')
 
-  function updateTable (): void {
-    $('#live-scores-table tbody tr').each(function () {
-      const managerId = Number($(this).data('manager-id'))
-      const scores = managerScores[managerId]
-      if (scores) {
-        $(this).find('.goals-for').text(scores.goals)
-        $(this).find('.goals-against').text(scores.conceded)
+  function setStatus (text: string, badge: string): void {
+    $status.text(text).removeClass('badge-secondary badge-success badge-warning badge-danger').addClass(badge)
+  }
+
+  function resultClass (score: LiveScore): string {
+    if (score.goals > score.conceded) { return 'badge-success' }
+    if (score.goals < score.conceded) { return 'badge-danger' }
+    return 'badge-primary'
+  }
+
+  function renderScorer (scorer: Scorer): JQuery<HTMLElement> {
+    const $link = $('<a>')
+      .attr('href', `/league/player/detail?playerId=${encodeURIComponent(String(scorer.playerId))}`)
+      .text(scorer.name)
+    const $em = $('<em>').append($link)
+    if (scorer.goals > 1) {
+      $em.append(document.createTextNode(` (${scorer.goals})`))
+    }
+    return $('<div class="row">').append($('<div class="col-md-12">').append($em))
+  }
+
+  function renderScoreRow (score: LiveScore): JQuery<HTMLElement> {
+    const $manager = $('<a>')
+      .attr('href', `/manager?managerId=${encodeURIComponent(String(score.managerId))}`)
+      .text(score.manager)
+
+    const $badge = $('<span>')
+      .addClass(`badge ${resultClass(score)}`)
+      .text(`${score.goals} - ${score.conceded}`)
+
+    const $detail = $('<td>').append($('<div class="row">').append($('<div class="col-md-12">').append($badge)))
+    for (const scorer of score.scorers) {
+      $detail.append(renderScorer(scorer))
+    }
+
+    return $('<tr>')
+      .attr('data-manager-id', score.managerId)
+      .append($('<td>').append($manager))
+      .append($detail)
+  }
+
+  function renderScores (): void {
+    const ordered = [...scores.values()].sort((a, b) =>
+      b.goals - a.goals ||
+      a.conceded - b.conceded ||
+      a.manager.localeCompare(b.manager))
+
+    const $body = $('#live-scores-table tbody')
+    $body.empty()
+    for (const score of ordered) {
+      $body.append(renderScoreRow(score))
+    }
+  }
+
+  function addToFeed (event: GoalEvent, prepend: boolean): void {
+    const scorer = event.potentialGoalFor?.player || event.scorer?.name || 'Unknown'
+    const team = event.scoringTeam?.name || ''
+    const minute = event.minute ? `${event.minute}'` : ''
+
+    const $row = $('<tr>')
+      .append($('<td class="numeric">').text(minute))
+      .append($('<td>').text(scorer))
+      .append($('<td>').text(team))
+
+    if (prepend) {
+      $feed.prepend($row)
+    } else {
+      $feed.append($row)
+    }
+
+    $feed.children().slice(MAX_FEED_ROWS).remove()
+    $feedEmpty.hide()
+  }
+
+  function isMatched (event: GoalEvent): boolean {
+    return Boolean(event?.potentialGoalFor?.managerId || event?.potentialConcedingFor?.managerId)
+  }
+
+  function applyGoal (event: GoalEvent): boolean {
+    if (!event?.id || countedEventIds.has(event.id) || !isMatched(event)) { return false }
+
+    countedEventIds.add(event.id)
+
+    const scoredFor = event.potentialGoalFor
+    if (scoredFor?.managerId) {
+      const score = scores.get(scoredFor.managerId)
+      if (score) {
+        score.goals++
+        const existing = score.scorers.find(s => s.playerId === scoredFor.playerId)
+        if (existing) {
+          existing.goals++
+        } else {
+          score.scorers.push({ playerId: scoredFor.playerId, name: scoredFor.player, goals: 1 })
+        }
+        score.scorers.sort((a, b) => b.goals - a.goals || a.name.localeCompare(b.name))
+      }
+    }
+
+    const concededFor = event.potentialConcedingFor
+    if (concededFor?.managerId) {
+      const score = scores.get(concededFor.managerId)
+      if (score) { score.conceded++ }
+    }
+
+    return true
+  }
+
+  function seedFeed (): void {
+    if (!historyUrl) { return }
+
+    $.getJSON(historyUrl).done(function (data: { events?: GoalEvent[] }) {
+      // The server summary already counted these, so only record the ids to stop the stream double counting.
+      for (const event of (data?.events || []).filter(isMatched)) {
+        if (!event.id || countedEventIds.has(event.id)) { continue }
+        countedEventIds.add(event.id)
+        addToFeed(event, false)
       }
     })
   }
 
-  function addGoalToFeed (event: any): void {
-    const scorer = event.scorer?.name || 'Unknown'
-    const team = event.scoringTeam?.name || ''
-    const minute = event.minute ? `${event.minute}'` : ''
-    const manager = event.potentialGoalFor?.manager || ''
-    const managerBadge = manager ? `<span class="badge badge-success ml-2">${manager}</span>` : ''
-
-    const html = `<div class="alert alert-success py-1 px-2 mb-1">
-      <strong>${minute}</strong> ${scorer} (${team}) ${managerBadge}
-    </div>`
-    $feed.prepend(html)
-  }
-
-  if (!videprinterStreamUrl) {
-    $status.text('No stream').removeClass('badge-secondary').addClass('badge-warning')
+  if (!streamUrl) {
+    setStatus('Unavailable', 'badge-warning')
     return
   }
 
-  const source = new EventSource(videprinterStreamUrl)
+  seedFeed()
+
+  const source = new EventSource(streamUrl)
 
   source.addEventListener('connected', function () {
-    $status.text('Connected').removeClass('badge-secondary').addClass('badge-success')
+    setStatus('Live', 'badge-success')
   })
 
-  source.addEventListener('goal', function (e: any) {
-    const event = JSON.parse(e.data)
-
-    if (event.potentialGoalFor?.manager) {
-      const managerId = findManagerId(event.potentialGoalFor.manager)
-      if (managerId && managerScores[managerId]) {
-        managerScores[managerId].goals++
-      }
+  source.addEventListener('goal', function (e: MessageEvent) {
+    let event: GoalEvent
+    try {
+      event = JSON.parse(e.data)
+    } catch {
+      return
     }
 
-    if (event.potentialConcedingFor?.manager) {
-      const managerId = findManagerId(event.potentialConcedingFor.manager)
-      if (managerId && managerScores[managerId]) {
-        managerScores[managerId].conceded++
-      }
-    }
+    if (!applyGoal(event)) { return }
 
-    updateTable()
-    addGoalToFeed(event)
+    renderScores()
+    addToFeed(event, true)
   })
 
   source.onerror = function () {
-    $status.text('Disconnected').removeClass('badge-success badge-secondary').addClass('badge-danger')
+    // EventSource retries on its own, so only report a hard failure once it has given up.
+    if (source.readyState === EventSource.CLOSED) {
+      setStatus('Disconnected', 'badge-danger')
+    } else {
+      setStatus('Reconnecting', 'badge-warning')
+    }
   }
-
-  function findManagerId (managerName: string): number | null {
-    const $rows = $('#live-scores-table tbody tr')
-    let found: number | null = null
-    $rows.each(function () {
-      const name = $(this).find('td:first').text()
-      if (name === managerName) {
-        found = Number($(this).data('manager-id'))
-        return false
-      }
-    })
-    return found
-  }
-
-  updateTable()
 })

--- a/src/client/javascripts/live.ts
+++ b/src/client/javascripts/live.ts
@@ -24,6 +24,10 @@ interface GoalEvent {
 
 const MAX_FEED_ROWS = 50
 
+function isMatched (event: GoalEvent): boolean {
+  return Boolean(event?.potentialGoalFor?.managerId || event?.potentialConcedingFor?.managerId)
+}
+
 $(function () {
   const liveData = JSON.parse($('#live-data').text() || '{}')
   const streamUrl: string = liveData.streamUrl || ''
@@ -112,10 +116,6 @@ $(function () {
 
     $feed.children().slice(MAX_FEED_ROWS).remove()
     $feedEmpty.hide()
-  }
-
-  function isMatched (event: GoalEvent): boolean {
-    return Boolean(event?.potentialGoalFor?.managerId || event?.potentialConcedingFor?.managerId)
   }
 
   function applyGoal (event: GoalEvent): boolean {

--- a/src/routes/api/managers.ts
+++ b/src/routes/api/managers.ts
@@ -2,6 +2,7 @@ import type { ServerRoute } from '@hapi/hapi'
 import { get } from '../../api/get.ts'
 
 interface TeamsheetTeam {
+  managerId: number
   name: string
   players: { playerId: number; lastNameFirstName: string; position: string; team: string; substitute: boolean }[]
   keepers: { teamId: number; name: string; substitute: boolean }[]
@@ -17,6 +18,7 @@ function formatTeamsheet (teamsheet: TeamsheetTeam[]): { data: { players: unknow
         name: player.lastNameFirstName,
         position: player.position,
         team: player.team,
+        managerId: team.managerId,
         manager: team.name,
         substitute: player.substitute,
       })
@@ -25,6 +27,7 @@ function formatTeamsheet (teamsheet: TeamsheetTeam[]): { data: { players: unknow
       goalkeepers.push({
         teamId: keeper.teamId,
         name: keeper.name,
+        managerId: team.managerId,
         manager: team.name,
         substitute: keeper.substitute,
       })

--- a/src/routes/live.ts
+++ b/src/routes/live.ts
@@ -2,48 +2,75 @@ import type { ServerRoute } from '@hapi/hapi'
 import Wreck from '@hapi/wreck'
 import { get } from '../api/get.ts'
 import config from '../config.ts'
+import { buildLiveScores } from './models/live.ts'
+
+const SUMMARY_TIMEOUT_MS = 3000
+
+// Escaped so a '</script>' in any value cannot break out of the JSON island.
+function toJsonIsland (data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
+async function getActiveGameweek (request: any): Promise<any> {
+  try {
+    const gameweeks = await get('/gameweeks', request) as any[]
+    const active = Array.isArray(gameweeks) ? gameweeks.filter((gw: any) => gw.isActive) : []
+    return active.length > 0 ? active[active.length - 1] : null
+  } catch (err: any) {
+    request.log(['warn', 'api'], { msg: 'Failed to fetch gameweeks for live view', err: err?.message })
+    return null
+  }
+}
+
+async function getLiveSummary (request: any, videprinterHost: string, gameweek: any): Promise<any> {
+  if (!gameweek) { return null }
+
+  const startDate = new Date(gameweek.startDate)
+  const endDate = new Date(startDate)
+  endDate.setDate(endDate.getDate() + 6)
+  endDate.setHours(23, 59, 59, 999)
+
+  try {
+    const summaryUrl = `${videprinterHost}/videprinter/summary?from=${startDate.toISOString()}&to=${endDate.toISOString()}`
+    const { payload } = await Wreck.get(summaryUrl, { json: true, timeout: SUMMARY_TIMEOUT_MS })
+    return payload
+  } catch (err: any) {
+    request.log(['warn', 'videprinter'], { msg: 'Failed to fetch live summary', err: err?.message })
+    return null
+  }
+}
+
+async function getManagers (request: any): Promise<any[]> {
+  try {
+    return await get('/managers', request) as any[]
+  } catch (err: any) {
+    request.log(['warn', 'api'], { msg: 'Failed to fetch managers for live view', err: err?.message })
+    return []
+  }
+}
 
 const routes: ServerRoute[] = [{
   method: 'GET',
   path: '/live',
   handler: async (request, h) => {
-    const gameweeks = await get('/gameweeks', request) as any[]
-    const activeGameweeks = Array.isArray(gameweeks) ? gameweeks.filter((gw: any) => gw.isActive) : []
-    const activeGameweek = activeGameweeks.length > 0 ? activeGameweeks[activeGameweeks.length - 1] : null
-
-    let liveSummary = null
     const videprinterHost = config.get('videprinterHost')
-    const videprinterStreamUrl = `${videprinterHost}/videprinter/stream`
+    const gameweek = await getActiveGameweek(request)
+    const [liveSummary, managers] = await Promise.all([
+      getLiveSummary(request, videprinterHost, gameweek),
+      getManagers(request),
+    ])
 
-    if (activeGameweek) {
-      const startDate = new Date(activeGameweek.startDate)
-      const endDate = new Date(startDate)
-      endDate.setDate(endDate.getDate() + 6)
-      endDate.setHours(23, 59, 59, 999)
-
-      try {
-        const summaryUrl = `${videprinterHost}/videprinter/summary?from=${startDate.toISOString()}&to=${endDate.toISOString()}`
-        const { payload } = await Wreck.get(summaryUrl, { json: true })
-        liveSummary = payload
-      } catch (err: any) {
-        request.log(['warn', 'videprinter'], { msg: 'Failed to fetch live summary', err: err?.message })
-        liveSummary = null
-      }
-    }
-
-    let managers: any[] = []
-    try {
-      managers = await get('/managers', request) as any[]
-    } catch (err: any) {
-      request.log(['warn', 'api'], { msg: 'Failed to fetch managers for live view', err: err?.message })
-      managers = []
-    }
+    const scores = buildLiveScores(managers, liveSummary)
 
     return h.view('live', {
-      gameweek: activeGameweek,
-      liveSummary,
-      managers,
-      videprinterStreamUrl,
+      gameweek,
+      scores,
+      videprinterAvailable: liveSummary !== null,
+      liveDataJson: toJsonIsland({
+        streamUrl: `${videprinterHost}/videprinter/stream`,
+        historyUrl: `${videprinterHost}/videprinter/history?limit=200`,
+        scores,
+      }),
     })
   },
 }]

--- a/src/routes/live.ts
+++ b/src/routes/live.ts
@@ -8,14 +8,14 @@ const SUMMARY_TIMEOUT_MS = 3000
 
 // Escaped so a '</script>' in any value cannot break out of the JSON island.
 function toJsonIsland (data: unknown): string {
-  return JSON.stringify(data).replace(/</g, '\\u003c')
+  return JSON.stringify(data).replaceAll('<', String.raw`\u003c`)
 }
 
 async function getActiveGameweek (request: any): Promise<any> {
   try {
     const gameweeks = await get('/gameweeks', request) as any[]
     const active = Array.isArray(gameweeks) ? gameweeks.filter((gw: any) => gw.isActive) : []
-    return active.length > 0 ? active[active.length - 1] : null
+    return active.at(-1) ?? null
   } catch (err: any) {
     request.log(['warn', 'api'], { msg: 'Failed to fetch gameweeks for live view', err: err?.message })
     return null

--- a/src/routes/models/live.ts
+++ b/src/routes/models/live.ts
@@ -1,0 +1,69 @@
+interface Scorer {
+  playerId: number
+  name: string
+  goals: number
+}
+
+interface Manager {
+  managerId: number
+  name: string
+}
+
+interface ManagerSummary {
+  managerId: number
+  manager: string
+  goals: number
+  conceded: number
+  scorers: Scorer[]
+}
+
+interface LiveSummary {
+  managers?: ManagerSummary[]
+}
+
+export interface LiveScore {
+  managerId: number
+  manager: string
+  goals: number
+  conceded: number
+  result: string
+  scorers: Scorer[]
+}
+
+export function getResult (goals: number, conceded: number): string {
+  if (goals > conceded) { return 'W' }
+  if (goals < conceded) { return 'L' }
+  return 'D'
+}
+
+export function sortScores (scores: LiveScore[]): LiveScore[] {
+  return scores.sort((a, b) =>
+    b.goals - a.goals ||
+    a.conceded - b.conceded ||
+    a.manager.localeCompare(b.manager))
+}
+
+export function buildLiveScores (managers: Manager[] = [], liveSummary: LiveSummary | null = null): LiveScore[] {
+  const summaries = new Map<number, ManagerSummary>()
+  for (const summary of liveSummary?.managers ?? []) {
+    summaries.set(summary.managerId, summary)
+  }
+
+  const scores = managers.map(manager => {
+    const summary = summaries.get(manager.managerId)
+    const goals = summary?.goals ?? 0
+    const conceded = summary?.conceded ?? 0
+    return {
+      managerId: manager.managerId,
+      manager: manager.name,
+      goals,
+      conceded,
+      result: getResult(goals, conceded),
+      scorers: summary?.scorers ?? [],
+    }
+  })
+
+  return sortScores(scores)
+}
+
+export default buildLiveScores

--- a/src/views/_live-scores.njk
+++ b/src/views/_live-scores.njk
@@ -1,0 +1,29 @@
+<table class="table table-hover table-sm small" id="live-scores-table">
+  <tbody>
+    {% for score in scores %}
+      <tr data-manager-id="{{ score.managerId }}">
+        <td><a href="/manager?managerId={{ score.managerId }}">{{ score.manager }}</a></td>
+        <td>
+          <div class="row">
+            <div class="col-md-12">
+              <span class="badge {% if score.result === 'W' %}badge-success{% elif score.result === 'L' %}badge-danger{% else %}badge-primary{% endif %}">{{ score.goals }} - {{ score.conceded }}</span>
+            </div>
+          </div>
+          {% for scorer in score.scorers %}
+            <div class="row">
+              <div class="col-md-12">
+                <em>
+                  <a href="/league/player/detail?playerId={{ scorer.playerId }}">{{ scorer.name }}</a>
+
+                  {% if scorer.goals > 1 %}
+                    ({{ scorer.goals }})
+                  {% endif %}
+                </em>
+              </div>
+            </div>
+          {% endfor %}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/src/views/live.njk
+++ b/src/views/live.njk
@@ -9,66 +9,40 @@
 
 <p class="text-muted">Week {{ gameweek.gameweekId }} ({{ gameweek.shortDate }})</p>
 
-<div class="row mb-4">
-  <div class="col-12">
+{% if not videprinterAvailable %}
+<div class="alert alert-warning">Live scores are unavailable at the moment. Goals will appear here once the feed is back.</div>
+{% endif %}
+
+<div class="row" style="padding-bottom: 20px;">
+  <div class="col-md-6" style="padding-bottom: 20px;">
     <div class="card border-dark">
       <div class="card-header bg-dark text-light">
-        Manager Scores (Live)
+        Scores
       </div>
       <div class="card-body">
-        <div class="table-responsive">
-          <table class="table table-hover table-sm" id="live-scores-table">
-            <thead>
-              <tr>
-                <th>Manager</th>
-                <th>Goals</th>
-                <th>Conceded</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for manager in managers %}
-              <tr data-manager-id="{{ manager.managerId }}">
-                <td>{{ manager.name }}</td>
-                <td class="goals-for">0</td>
-                <td class="goals-against">0</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+        {% include "./_live-scores.njk" %}
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card border-dark">
+      <div class="card-header bg-dark text-light">
+        Goals
+        <span id="connection-status" class="badge badge-secondary float-right">Connecting</span>
+      </div>
+      <div class="card-body">
+        <table class="table table-hover table-sm small">
+          <tbody id="goal-feed"></tbody>
+        </table>
+        <p id="goal-feed-empty" class="text-muted small">Goals will appear here as they are scored.</p>
       </div>
     </div>
   </div>
 </div>
 
-<div class="row">
-  <div class="col-md-8">
-    <div class="card border-dark">
-      <div class="card-header bg-dark text-light">
-        <span id="connection-status" class="badge badge-secondary mr-2">Connecting...</span>
-        Goal Feed
-      </div>
-      <div class="card-body">
-        <div id="goal-feed">
-          {% if not liveSummary %}
-          <p class="text-muted">No live data available. Goals will appear here during matches.</p>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<p class="text-muted small">Scores update automatically every few minutes.</p>
 
-<script id="live-data" type="application/json">
-  {
-    "videprinterStreamUrl": "{{ videprinterStreamUrl }}",
-    "managers": [
-      {% for manager in managers %}
-        { "managerId": {{ manager.managerId }}, "name": "{{ manager.name }}" }{% if not loop.last %},{% endif %}
-      {% endfor %}
-    ]
-  }
-</script>
+<script id="live-data" type="application/json">{{ liveDataJson | safe }}</script>
 <script src="{{ asset('javascripts/live.js') }}"></script>
 {% endif %}
 {% endblock %}

--- a/test/integration/live-route.test.ts
+++ b/test/integration/live-route.test.ts
@@ -1,0 +1,102 @@
+import { vi } from 'vitest'
+
+const { mockGet, mockWreckGet } = vi.hoisted(() => ({ mockGet: vi.fn(), mockWreckGet: vi.fn() }))
+
+vi.mock('../../src/api/get.ts', () => ({ get: mockGet }))
+vi.mock('@hapi/wreck', () => ({ default: { get: mockWreckGet } }))
+
+const routes = (await import('../../src/routes/live.ts')).default
+
+const handler = routes[0]!.handler as any
+
+const request = { log: vi.fn() }
+
+function view (): any {
+  return { view: (template: string, context: any) => ({ template, context }) }
+}
+
+const gameweek = { gameweekId: 5, startDate: '2026-08-08T00:00:00.000Z', shortDate: '08/08/2026', isActive: true }
+const managers = [{ managerId: 1, name: 'Alice' }, { managerId: 2, name: 'Bob' }]
+
+function mockApi (overrides: Record<string, unknown> = {}): void {
+  mockGet.mockImplementation(async (path: string) => {
+    if (path === '/gameweeks') { return overrides.gameweeks ?? [gameweek] }
+    if (path === '/managers') { return overrides.managers ?? managers }
+    return []
+  })
+}
+
+describe('live route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders the live view with scores seeded from the videprinter summary', async () => {
+    mockApi()
+    mockWreckGet.mockResolvedValue({
+      payload: {
+        managers: [{ managerId: 2, manager: 'Bob', goals: 2, conceded: 1, scorers: [{ playerId: 9, name: 'Smith, John', goals: 2 }] }],
+      },
+    })
+
+    const { template, context } = await handler(request, view())
+
+    expect(template).toBe('live')
+    expect(context.videprinterAvailable).toBe(true)
+    expect(context.scores[0]).toMatchObject({ manager: 'Bob', goals: 2, conceded: 1, result: 'W' })
+    expect(context.scores[0].scorers).toHaveLength(1)
+  })
+
+  test('requests the summary for the full gameweek', async () => {
+    mockApi()
+    mockWreckGet.mockResolvedValue({ payload: { managers: [] } })
+
+    await handler(request, view())
+
+    const [url, options] = mockWreckGet.mock.calls[0]!
+    expect(url).toContain('/videprinter/summary?from=2026-08-08')
+    expect(options.timeout).toBeGreaterThan(0)
+  })
+
+  test('degrades gracefully when the videprinter is unreachable', async () => {
+    mockApi()
+    mockWreckGet.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const { context } = await handler(request, view())
+
+    expect(context.videprinterAvailable).toBe(false)
+    expect(context.scores).toHaveLength(2)
+    expect(context.scores.every((s: any) => s.goals === 0)).toBe(true)
+  })
+
+  test('does not call the videprinter when there is no active gameweek', async () => {
+    mockApi({ gameweeks: [{ ...gameweek, isActive: false }] })
+
+    const { context } = await handler(request, view())
+
+    expect(mockWreckGet).not.toHaveBeenCalled()
+    expect(context.gameweek).toBeNull()
+  })
+
+  test('renders when the managers call fails', async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === '/gameweeks') { return [gameweek] }
+      throw new Error('api down')
+    })
+    mockWreckGet.mockResolvedValue({ payload: { managers: [] } })
+
+    const { context } = await handler(request, view())
+
+    expect(context.scores).toEqual([])
+  })
+
+  test('escapes markup in the json island so it cannot break out of the script tag', async () => {
+    mockApi({ managers: [{ managerId: 1, name: '</script><img src=x onerror=alert(1)>' }] })
+    mockWreckGet.mockResolvedValue({ payload: { managers: [] } })
+
+    const { context } = await handler(request, view())
+
+    expect(context.liveDataJson).not.toContain('</script>')
+    expect(context.liveDataJson).toContain('\\u003c/script')
+  })
+})

--- a/test/unit/routes-models-live.test.ts
+++ b/test/unit/routes-models-live.test.ts
@@ -1,0 +1,108 @@
+import { buildLiveScores, getResult, sortScores } from '../../src/routes/models/live.ts'
+
+const managers = [
+  { managerId: 1, name: 'Alice' },
+  { managerId: 2, name: 'Bob' },
+  { managerId: 3, name: 'Charlie' },
+]
+
+describe('live view model', () => {
+  test('returns every manager with zero scores when there is no summary', () => {
+    const result = buildLiveScores(managers, null)
+
+    expect(result).toHaveLength(3)
+    expect(result.every(s => s.goals === 0 && s.conceded === 0)).toBe(true)
+    expect(result.every(s => s.scorers.length === 0)).toBe(true)
+  })
+
+  test('seeds goals, conceded and scorers from the summary', () => {
+    const result = buildLiveScores(managers, {
+      managers: [{
+        managerId: 2,
+        manager: 'Bob',
+        goals: 3,
+        conceded: 1,
+        scorers: [{ playerId: 10, name: 'Smith, John', goals: 2 }],
+      }],
+    })
+
+    const bob = result.find(s => s.managerId === 2)!
+    expect(bob.goals).toBe(3)
+    expect(bob.conceded).toBe(1)
+    expect(bob.scorers).toEqual([{ playerId: 10, name: 'Smith, John', goals: 2 }])
+  })
+
+  test('uses the manager name from the API rather than the videprinter summary', () => {
+    const result = buildLiveScores(managers, {
+      managers: [{ managerId: 1, manager: 'A Lice', goals: 1, conceded: 0, scorers: [] }],
+    })
+
+    expect(result[0]!.manager).toBe('Alice')
+  })
+
+  test('ignores summary entries for unknown managers', () => {
+    const result = buildLiveScores(managers, {
+      managers: [{ managerId: 99, manager: 'Nobody', goals: 5, conceded: 0, scorers: [] }],
+    })
+
+    expect(result).toHaveLength(3)
+    expect(result.some(s => s.manager === 'Nobody')).toBe(false)
+  })
+
+  test('sorts by goals descending, then conceded ascending, then name', () => {
+    const result = buildLiveScores(managers, {
+      managers: [
+        { managerId: 1, manager: 'Alice', goals: 2, conceded: 4, scorers: [] },
+        { managerId: 2, manager: 'Bob', goals: 5, conceded: 0, scorers: [] },
+        { managerId: 3, manager: 'Charlie', goals: 2, conceded: 1, scorers: [] },
+      ],
+    })
+
+    expect(result.map(s => s.manager)).toEqual(['Bob', 'Charlie', 'Alice'])
+  })
+
+  test('falls back to alphabetical order when nobody has scored', () => {
+    const result = buildLiveScores([
+      { managerId: 3, name: 'Charlie' },
+      { managerId: 1, name: 'Alice' },
+      { managerId: 2, name: 'Bob' },
+    ], null)
+
+    expect(result.map(s => s.manager)).toEqual(['Alice', 'Bob', 'Charlie'])
+  })
+
+  test('handles an empty manager list', () => {
+    expect(buildLiveScores([], null)).toEqual([])
+  })
+})
+
+describe('live result derivation', () => {
+  test.each([
+    [3, 1, 'W'],
+    [1, 3, 'L'],
+    [2, 2, 'D'],
+    [0, 0, 'D'],
+  ])('%i - %i is %s', (goals, conceded, expected) => {
+    expect(getResult(goals, conceded)).toBe(expected)
+  })
+
+  test('result is set on each seeded score', () => {
+    const result = buildLiveScores(managers, {
+      managers: [{ managerId: 1, manager: 'Alice', goals: 4, conceded: 2, scorers: [] }],
+    })
+
+    expect(result.find(s => s.managerId === 1)!.result).toBe('W')
+    expect(result.find(s => s.managerId === 2)!.result).toBe('D')
+  })
+})
+
+describe('live score sorting', () => {
+  test('is stable for identical scores', () => {
+    const scores = [
+      { managerId: 2, manager: 'Bob', goals: 1, conceded: 1, result: 'D', scorers: [] },
+      { managerId: 1, manager: 'Alice', goals: 1, conceded: 1, result: 'D', scorers: [] },
+    ]
+
+    expect(sortScores(scores).map(s => s.manager)).toEqual(['Alice', 'Bob'])
+  })
+})


### PR DESCRIPTION
Rebuilds the live matchday page. The feature has never been used in anger, so this is a review pass ahead of the new season covering correctness, security and styling.

Requires johnwatson484/dream-league-videprinter#9.

## Security

The client built feed rows by interpolating into an HTML string and calling `$feed.prepend(html)`. Scorer, player and team names come from an external goal feed, so this was a stored XSS sink.

- All DOM now built with text nodes, and hrefs pass through `encodeURIComponent`.
- Verified with an `<img src=x onerror=...>` payload injected through both the history and stream paths; it renders as literal text and does not execute.

## The page reset itself on refresh

`/videprinter/summary` was fetched but only used for an `{% if not liveSummary %}` check, so a refresh mid-matchday dropped every score back to 0 - 0.

- New `routes/models/live` view model maps every manager from the API and seeds goals, conceded and scorers from the summary.
- Scores now render server-side, so the page is correct before any JavaScript runs.

## The JSON island was breaking

The client payload was hand-built JSON inside a `<script>` tag, so it went through Nunjucks autoescape. An apostrophe or ampersand in a manager name produced entities that script raw text never decodes, `JSON.parse` threw, and every live update died silently. Dream League has managers with apostrophes in their names.

- Serialised server-side with `JSON.stringify`, `<` escaped so a value cannot break out of the tag, emitted with `| safe`.

## Styling

- Scores render through a new `_live-scores.njk` using the same markup and result badge colours as `_scores.njk`, with scorers listed underneath and a `(n)` tally for multiples.
- Two-column layout: scores on the left, chronological goal feed on the right, both in the site's `card border-dark` style.

## Reliability

- Manager matching now uses `managerId`, threaded through `/api/v1/manager/teams`, rather than comparing rendered `<td>` text to a name.
- SSE events deduped by id, so a reconnect cannot double count.
- Goal feed backfilled from `/videprinter/history` on load.
- Connection badge only reports Disconnected once `EventSource` has actually given up, instead of latching on the first transient error.
- 3s timeout on the summary request, so the page still renders if the videprinter is down, with a warning shown.

## Testing

88 tests passing across 18 files; lint, typecheck and frontend build clean. New unit tests for the view model and integration tests for the route, including the JSON island escaping.

Verified end to end in a browser against the real seeded data: scores seeded from the summary, badge colours correct, dedupe working, scorer tallies and re-sorting on live goals, feed newest-first, and no console errors.