### PR TITLE
Allow live refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ COOKIE_PASSWORD=must-be-at-least-32-characters-long!!
 REDIS_HOST=localhost
 REDIS_PORT=6380
 REDIS_PASSWORD=redis
+# Must match API_KEY in dream-league-videprinter.
+VIDEPRINTER_API_KEY=must-be-at-least-32-characters-long!!

--- a/README.md
+++ b/README.md
@@ -71,5 +71,14 @@ For running the full stack (API + Web), see the [dream-league-core](https://gith
 | `REDIS_HOST` | Redis host for session storage | `localhost` | No |
 | `REDIS_PORT` | Redis port | `6380` | No |
 | `REDIS_PASSWORD` | Redis password | `''` | No |
+| `VIDEPRINTER_HOST` | Videprinter service base URL | `http://localhost:3002` | No |
+| `VIDEPRINTER_API_KEY` | API key sent to the videprinter service for admin actions (e.g. goal rematch). Must match `API_KEY` in dream-league-videprinter | `''` | No |
 
 Cookie `isSecure` is automatically set to `true` in production and `false` in development/test.
+
+## Admin: refreshing live goals
+
+Admins see a "Refresh goals" button on the `/live` page. It calls `POST /live/refresh`, which asks
+dream-league-videprinter to re-fetch current teamsheets and rematch every stored goal event - useful
+when a goal was scored before a manager's teamsheet was corrected. Requires `VIDEPRINTER_API_KEY` to be
+set and to match the videprinter's `API_KEY`.

--- a/src/api/videprinter.ts
+++ b/src/api/videprinter.ts
@@ -1,0 +1,21 @@
+import Wreck from '@hapi/wreck'
+import config from '../config.ts'
+
+const REMATCH_TIMEOUT_MS = 15000
+
+export interface RematchSummary {
+  eventsProcessed: number
+  eventsChanged: number
+  unmatched: number
+  teamsheet: unknown
+}
+
+export async function triggerGoalRematch (): Promise<RematchSummary> {
+  const url = `${config.get('videprinterHost')}/videprinter/rematch`
+  const { payload } = await Wreck.post(url, {
+    json: true,
+    timeout: REMATCH_TIMEOUT_MS,
+    headers: { 'x-api-key': config.get('videprinterApiKey') },
+  })
+  return payload as RematchSummary
+}

--- a/src/client/javascripts/live.ts
+++ b/src/client/javascripts/live.ts
@@ -44,6 +44,28 @@ $(function () {
   const $feed = $('#goal-feed')
   const $feedEmpty = $('#goal-feed-empty')
 
+  const $refreshButton = $('#refresh-goals')
+  const $refreshStatus = $('#refresh-status')
+
+  $refreshButton.on('click', function () {
+    $refreshButton.prop('disabled', true)
+    $refreshStatus.text('Refreshing…')
+    $.ajax({
+      type: 'POST',
+      url: '/live/refresh',
+      data: { crumb: $('#refresh-crumb').val() },
+      success: function (summary: { eventsChanged?: number }) {
+        $refreshStatus.text(`Done - ${summary?.eventsChanged ?? 0} goal(s) updated. Reload to see changes.`)
+      },
+      error: function () {
+        $refreshStatus.text('Refresh failed. Please try again.')
+      },
+      complete: function () {
+        $refreshButton.prop('disabled', false)
+      },
+    })
+  })
+
   function setStatus (text: string, badge: string): void {
     $status.text(text).removeClass('badge-secondary badge-success badge-warning badge-danger').addClass(badge)
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,13 @@ const config = convict({
     default: 'http://localhost:3002',
     env: 'VIDEPRINTER_HOST',
   },
+  videprinterApiKey: {
+    doc: 'API key sent to the videprinter service for admin actions (e.g. goal rematch).',
+    format: String,
+    default: '',
+    env: 'VIDEPRINTER_API_KEY',
+    sensitive: true,
+  },
   session: {
     cookieName: {
       doc: 'The session cookie name.',

--- a/src/routes/live.ts
+++ b/src/routes/live.ts
@@ -1,8 +1,10 @@
 import type { ServerRoute } from '@hapi/hapi'
 import Wreck from '@hapi/wreck'
+import boom from '@hapi/boom'
 import { get } from '../api/get.ts'
 import config from '../config.ts'
 import { buildLiveScores } from './models/live.ts'
+import { triggerGoalRematch } from '../api/videprinter.ts'
 
 const SUMMARY_TIMEOUT_MS = 3000
 
@@ -72,6 +74,21 @@ const routes: ServerRoute[] = [{
         scores,
       }),
     })
+  },
+}, {
+  method: 'POST',
+  path: '/live/refresh',
+  options: {
+    auth: { strategy: 'session', scope: ['admin'] },
+  },
+  handler: async (request, h) => {
+    try {
+      const summary = await triggerGoalRematch()
+      return h.response(summary)
+    } catch (err: any) {
+      request.log(['warn', 'videprinter'], { msg: 'Failed to trigger goal rematch', err: err?.message })
+      return boom.badGateway('Unable to reach videprinter service')
+    }
   },
 }]
 

--- a/src/views/live.njk
+++ b/src/views/live.njk
@@ -13,6 +13,14 @@
 <div class="alert alert-warning">Live scores are unavailable at the moment. Goals will appear here once the feed is back.</div>
 {% endif %}
 
+{% if auth.isAdmin %}
+<div class="mb-3">
+  <input type="hidden" id="refresh-crumb" value="{{crumb}}"/>
+  <button id="refresh-goals" type="button" class="btn btn-sm btn-outline-dark">Refresh goals</button>
+  <span id="refresh-status" class="text-muted small ml-2"></span>
+</div>
+{% endif %}
+
 <div class="row" style="padding-bottom: 20px;">
   <div class="col-md-6" style="padding-bottom: 20px;">
     <div class="card border-dark">

--- a/test/integration/live-route.test.ts
+++ b/test/integration/live-route.test.ts
@@ -1,18 +1,24 @@
 import { vi } from 'vitest'
 
-const { mockGet, mockWreckGet } = vi.hoisted(() => ({ mockGet: vi.fn(), mockWreckGet: vi.fn() }))
+const { mockGet, mockWreckGet, mockTriggerGoalRematch } = vi.hoisted(() => ({ mockGet: vi.fn(), mockWreckGet: vi.fn(), mockTriggerGoalRematch: vi.fn() }))
 
 vi.mock('../../src/api/get.ts', () => ({ get: mockGet }))
 vi.mock('@hapi/wreck', () => ({ default: { get: mockWreckGet } }))
+vi.mock('../../src/api/videprinter.ts', () => ({ triggerGoalRematch: mockTriggerGoalRematch }))
 
 const routes = (await import('../../src/routes/live.ts')).default
 
 const handler = routes[0]!.handler as any
+const refreshRoute = routes[1]!
+const refreshHandler = refreshRoute.handler as any
 
 const request = { log: vi.fn() }
 
 function view (): any {
-  return { view: (template: string, context: any) => ({ template, context }) }
+  return {
+    view: (template: string, context: any) => ({ template, context }),
+    response: (source: any) => ({ source }),
+  }
 }
 
 const gameweek = { gameweekId: 5, startDate: '2026-08-08T00:00:00.000Z', shortDate: '08/08/2026', isActive: true }
@@ -98,5 +104,33 @@ describe('live route', () => {
 
     expect(context.liveDataJson).not.toContain('</script>')
     expect(context.liveDataJson).toContain('\\u003c/script')
+  })
+})
+
+describe('live refresh route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('is restricted to admins', () => {
+    expect(refreshRoute.method).toBe('POST')
+    expect(refreshRoute.options).toMatchObject({ auth: { strategy: 'session', scope: ['admin'] } })
+  })
+
+  test('returns the rematch summary on success', async () => {
+    mockTriggerGoalRematch.mockResolvedValue({ eventsProcessed: 5, eventsChanged: 2, unmatched: 1, teamsheet: {} })
+
+    const response = await refreshHandler(request, view())
+
+    expect(response.source).toMatchObject({ eventsProcessed: 5, eventsChanged: 2 })
+  })
+
+  test('returns a bad gateway response when the videprinter is unreachable', async () => {
+    mockTriggerGoalRematch.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const response = await refreshHandler(request, view())
+
+    expect(response.isBoom).toBe(true)
+    expect(response.output.statusCode).toBe(502)
   })
 })

--- a/test/integration/live-route.test.ts
+++ b/test/integration/live-route.test.ts
@@ -96,6 +96,29 @@ describe('live route', () => {
     expect(context.scores).toEqual([])
   })
 
+  test('renders with no active gameweek when the gameweeks call fails', async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === '/gameweeks') { throw new Error('api down') }
+      return managers
+    })
+
+    const { context } = await handler(request, view())
+
+    expect(context.gameweek).toBeNull()
+    expect(mockWreckGet).not.toHaveBeenCalled()
+  })
+
+  test('renders with no active gameweek when the gameweeks response is not an array', async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === '/gameweeks') { return null }
+      return managers
+    })
+
+    const { context } = await handler(request, view())
+
+    expect(context.gameweek).toBeNull()
+  })
+
   test('escapes markup in the json island so it cannot break out of the script tag', async () => {
     mockApi({ managers: [{ managerId: 1, name: '</script><img src=x onerror=alert(1)>' }] })
     mockWreckGet.mockResolvedValue({ payload: { managers: [] } })

--- a/test/unit/api-videprinter.test.ts
+++ b/test/unit/api-videprinter.test.ts
@@ -1,0 +1,25 @@
+import { vi } from 'vitest'
+
+const { mockWreckPost } = vi.hoisted(() => ({ mockWreckPost: vi.fn() }))
+
+vi.mock('@hapi/wreck', () => ({ default: { post: mockWreckPost } }))
+
+const { triggerGoalRematch } = await import('../../src/api/videprinter.ts')
+
+describe('triggerGoalRematch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('posts to the videprinter rematch endpoint with the api key header', async () => {
+    mockWreckPost.mockResolvedValue({ payload: { eventsProcessed: 3, eventsChanged: 1, unmatched: 0, teamsheet: {} } })
+
+    const summary = await triggerGoalRematch()
+
+    expect(mockWreckPost).toHaveBeenCalledWith(
+      'http://localhost:3002/videprinter/rematch',
+      expect.objectContaining({ headers: { 'x-api-key': '' }, json: true })
+    )
+    expect(summary.eventsProcessed).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary
Adds an admin-only "Refresh goals" action on the `/live` page to fix goals that were mismatched to the wrong manager because the teamsheet was incorrect when the goal event was originally processed.

- Admin-only button on `/live` (guarded by `auth.isAdmin`), POSTs to `/live/refresh`
- New route calls dream-league-videprinter's rematch endpoint via a new `src/api/videprinter.ts` client, authenticated with an API key header
- Returns a bad gateway response if the videprinter is unreachable

## Config
- `VIDEPRINTER_API_KEY` (optional, default `''`) — must match `API_KEY` in dream-league-videprinter

## Testing
- `npm run test` — 92/92 passing
- `npm run test:lint` — clean

Companion PR: johnwatson484/dream-league-videprinter#10 (adds the rematch endpoint this calls).