### PR TITLE
Fix live goal feed

### DIFF
--- a/src/client/javascripts/live.ts
+++ b/src/client/javascripts/live.ts
@@ -17,9 +17,8 @@ interface GoalEvent {
   id: string
   minute: number | null
   scorer?: { name: string }
-  scoringTeam?: { name: string }
-  potentialGoalFor?: { managerId: number; playerId: number; player: string }
-  potentialConcedingFor?: { managerId: number }
+  potentialGoalFor?: { managerId: number; manager: string; playerId: number; player: string }
+  potentialConcedingFor?: { managerId: number; manager: string }
 }
 
 const MAX_FEED_ROWS = 50
@@ -122,13 +121,13 @@ $(function () {
 
   function addToFeed (event: GoalEvent, prepend: boolean): void {
     const scorer = event.potentialGoalFor?.player || event.scorer?.name || 'Unknown'
-    const team = event.scoringTeam?.name || ''
+    const manager = event.potentialGoalFor?.manager || event.potentialConcedingFor?.manager || ''
     const minute = event.minute ? `${event.minute}'` : ''
 
     const $row = $('<tr>')
       .append($('<td class="numeric">').text(minute))
       .append($('<td>').text(scorer))
-      .append($('<td>').text(team))
+      .append($('<td>').text(manager))
 
     if (prepend) {
       $feed.prepend($row)

--- a/src/routes/live.ts
+++ b/src/routes/live.ts
@@ -24,7 +24,20 @@ async function getActiveGameweek (request: any): Promise<any> {
   }
 }
 
-async function getLiveSummary (request: any, videprinterHost: string, gameweek: any): Promise<any> {
+async function getLiveSummary (request: any, videprinterHost: string, window: { startDate: Date; endDate: Date } | null): Promise<any> {
+  if (!window) { return null }
+
+  try {
+    const summaryUrl = `${videprinterHost}/videprinter/summary?from=${window.startDate.toISOString()}&to=${window.endDate.toISOString()}`
+    const { payload } = await Wreck.get(summaryUrl, { json: true, timeout: SUMMARY_TIMEOUT_MS })
+    return payload
+  } catch (err: any) {
+    request.log(['warn', 'videprinter'], { msg: 'Failed to fetch live summary', err: err?.message })
+    return null
+  }
+}
+
+function getGameweekWindow (gameweek: any): { startDate: Date; endDate: Date } | null {
   if (!gameweek) { return null }
 
   const startDate = new Date(gameweek.startDate)
@@ -32,14 +45,7 @@ async function getLiveSummary (request: any, videprinterHost: string, gameweek: 
   endDate.setDate(endDate.getDate() + 6)
   endDate.setHours(23, 59, 59, 999)
 
-  try {
-    const summaryUrl = `${videprinterHost}/videprinter/summary?from=${startDate.toISOString()}&to=${endDate.toISOString()}`
-    const { payload } = await Wreck.get(summaryUrl, { json: true, timeout: SUMMARY_TIMEOUT_MS })
-    return payload
-  } catch (err: any) {
-    request.log(['warn', 'videprinter'], { msg: 'Failed to fetch live summary', err: err?.message })
-    return null
-  }
+  return { startDate, endDate }
 }
 
 async function getManagers (request: any): Promise<any[]> {
@@ -57,12 +63,14 @@ const routes: ServerRoute[] = [{
   handler: async (request, h) => {
     const videprinterHost = config.get('videprinterHost')
     const gameweek = await getActiveGameweek(request)
+    const window = getGameweekWindow(gameweek)
     const [liveSummary, managers] = await Promise.all([
-      getLiveSummary(request, videprinterHost, gameweek),
+      getLiveSummary(request, videprinterHost, window),
       getManagers(request),
     ])
 
     const scores = buildLiveScores(managers, liveSummary)
+    const historyParams = window ? `&from=${window.startDate.toISOString()}&to=${window.endDate.toISOString()}` : ''
 
     return h.view('live', {
       gameweek,
@@ -70,7 +78,7 @@ const routes: ServerRoute[] = [{
       videprinterAvailable: liveSummary !== null,
       liveDataJson: toJsonIsland({
         streamUrl: `${videprinterHost}/videprinter/stream`,
-        historyUrl: `${videprinterHost}/videprinter/history?limit=200`,
+        historyUrl: `${videprinterHost}/videprinter/history?limit=200${historyParams}`,
         scores,
       }),
     })

--- a/test/integration/live-route.test.ts
+++ b/test/integration/live-route.test.ts
@@ -64,6 +64,27 @@ describe('live route', () => {
     expect(options.timeout).toBeGreaterThan(0)
   })
 
+  test('scopes the goal feed history to the same gameweek window as the summary', async () => {
+    mockApi()
+    mockWreckGet.mockResolvedValue({ payload: { managers: [] } })
+
+    const { context } = await handler(request, view())
+
+    const liveData = JSON.parse(context.liveDataJson)
+    expect(liveData.historyUrl).toContain('/videprinter/history?limit=200')
+    expect(liveData.historyUrl).toContain('from=2026-08-08T00:00:00.000Z')
+    expect(liveData.historyUrl).toContain('to=2026-08-14T23:59:59.999Z')
+  })
+
+  test('omits the history date range when there is no active gameweek', async () => {
+    mockApi({ gameweeks: [{ ...gameweek, isActive: false }] })
+
+    const { context } = await handler(request, view())
+
+    const liveData = JSON.parse(context.liveDataJson)
+    expect(liveData.historyUrl).toBe('http://localhost:3002/videprinter/history?limit=200')
+  })
+
   test('degrades gracefully when the videprinter is unreachable', async () => {
     mockApi()
     mockWreckGet.mockRejectedValue(new Error('ECONNREFUSED'))


### PR DESCRIPTION
## Summary
Fixes two issues on the `/live` page's Goals mini feed reported after the previous "Allow live refresh" change was merged:
1. The feed showed goals from outside the current gameweek that didn't belong to any visible manager.
2. The feed showed the real-world team name instead of the Dream League manager name.

## Root cause
- `historyUrl` was built with no date range (`/videprinter/history?limit=200`), unlike the summary call which is correctly scoped to the active gameweek's window - so the feed picked up unrelated goals from outside the current week.
- `addToFeed()` in the client script used `event.scoringTeam.name` (real team) instead of the already-present `event.potentialGoalFor.manager` / `potentialConcedingFor.manager` fields.

## Change
- Extracted the gameweek date-window calculation in `src/routes/live.ts` into a shared helper and used it to add `from`/`to` params to `historyUrl` (requires companion videprinter PR).
- Updated `src/client/javascripts/live.ts`'s `GoalEvent` interface and `addToFeed()` to render the manager name.

## Testing
- `npm run test` - 96/96 passing
- `npm run test:lint` - clean

Companion PR: johnwatson484/dream-league-videprinter#11 (adds `from`/`to` support to the history endpoint this relies on).