### PR TITLE
Show goal date in live feed

### DIFF
--- a/src/client/javascripts/live.ts
+++ b/src/client/javascripts/live.ts
@@ -16,6 +16,7 @@ interface LiveScore {
 interface GoalEvent {
   id: string
   minute: number | null
+  utcTimestamp?: string
   scorer?: { name: string }
   potentialGoalFor?: { managerId: number; manager: string; playerId: number; player: string }
   potentialConcedingFor?: { managerId: number; manager: string }
@@ -119,13 +120,23 @@ $(function () {
     }
   }
 
+  function formatEventDate (event: GoalEvent): string {
+    if (!event.utcTimestamp) { return '' }
+    const date = new Date(event.utcTimestamp)
+    if (Number.isNaN(date.getTime())) { return '' }
+    const day = String(date.getDate()).padStart(2, '0')
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    return `${day}/${month}`
+  }
+
   function addToFeed (event: GoalEvent, prepend: boolean): void {
     const scorer = event.potentialGoalFor?.player || event.scorer?.name || 'Unknown'
     const manager = event.potentialGoalFor?.manager || event.potentialConcedingFor?.manager || ''
     const minute = event.minute ? `${event.minute}'` : ''
+    const dateMinute = [formatEventDate(event), minute].filter(Boolean).join(' ')
 
     const $row = $('<tr>')
-      .append($('<td class="numeric">').text(minute))
+      .append($('<td class="numeric">').text(dateMinute))
       .append($('<td>').text(scorer))
       .append($('<td>').text(manager))
 

--- a/src/client/javascripts/live.ts
+++ b/src/client/javascripts/live.ts
@@ -28,6 +28,15 @@ function isMatched (event: GoalEvent): boolean {
   return Boolean(event?.potentialGoalFor?.managerId || event?.potentialConcedingFor?.managerId)
 }
 
+function formatEventDate (event: GoalEvent): string {
+  if (!event.utcTimestamp) { return '' }
+  const date = new Date(event.utcTimestamp)
+  if (Number.isNaN(date.getTime())) { return '' }
+  const day = String(date.getDate()).padStart(2, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  return `${day}/${month}`
+}
+
 $(function () {
   const liveData = JSON.parse($('#live-data').text() || '{}')
   const streamUrl: string = liveData.streamUrl || ''
@@ -118,15 +127,6 @@ $(function () {
     for (const score of ordered) {
       $body.append(renderScoreRow(score))
     }
-  }
-
-  function formatEventDate (event: GoalEvent): string {
-    if (!event.utcTimestamp) { return '' }
-    const date = new Date(event.utcTimestamp)
-    if (Number.isNaN(date.getTime())) { return '' }
-    const day = String(date.getDate()).padStart(2, '0')
-    const month = String(date.getMonth() + 1).padStart(2, '0')
-    return `${day}/${month}`
   }
 
   function addToFeed (event: GoalEvent, prepend: boolean): void {


### PR DESCRIPTION
## Summary
Small follow-up to #31. Now that the goal feed's history is scoped to the whole gameweek window (not just "recent"), a goal's minute alone is ambiguous when it could be from a different day within that window.

## Change
- Prepends a compact `dd/MM` date to the existing minute column in the mini goal feed (e.g. `06/08 61'`), instead of adding a separate column, to keep the row narrow on mobile.

## Testing
- `npm run test` - 96/96 passing
- `npm run test:lint` - clean
- No existing test infrastructure for client-side scripts (`src/client/javascripts`), so this was verified manually.