### PR TITLE
Update live matchday

### DIFF
--- a/src/client/javascripts/live.ts
+++ b/src/client/javascripts/live.ts
@@ -19,10 +19,13 @@ interface GoalEvent {
   utcTimestamp?: string
   scorer?: { name: string }
   potentialGoalFor?: { managerId: number; manager: string; playerId: number; player: string }
-  potentialConcedingFor?: { managerId: number; manager: string }
+  potentialConcedingFor?: { managerId: number; manager: string; team: string }
 }
 
 const MAX_FEED_ROWS = 50
+const POLL_INTERVAL_MS = 60000
+const HEARTBEAT_DISPLAY_INTERVAL_MS = 5000
+const MAX_RETRY_DELAY_MS = 15000
 
 function isMatched (event: GoalEvent): boolean {
   return Boolean(event?.potentialGoalFor?.managerId || event?.potentialConcedingFor?.managerId)
@@ -41,6 +44,7 @@ $(function () {
   const liveData = JSON.parse($('#live-data').text() || '{}')
   const streamUrl: string = liveData.streamUrl || ''
   const historyUrl: string = liveData.historyUrl || ''
+  const initialGameweekId: number | null = liveData.gameweekId ?? null
 
   const scores = new Map<number, LiveScore>()
   for (const score of (liveData.scores || []) as LiveScore[]) {
@@ -48,15 +52,21 @@ $(function () {
   }
 
   const countedEventIds = new Set<string>()
+  let lastEventTimestamp: string | null = null
+  let lastHeartbeatTs: number | null = null
+  let statusIsLive = false
+  let retryDelay = 1000
+  let source: EventSource | null = null
 
   const $status = $('#connection-status')
   const $feed = $('#goal-feed')
   const $feedEmpty = $('#goal-feed-empty')
 
   const $refreshButton = $('#refresh-goals')
+  const $refreshConfirmButton = $('#refresh-confirm-btn')
   const $refreshStatus = $('#refresh-status')
 
-  $refreshButton.on('click', function () {
+  $refreshConfirmButton.on('click', function () {
     $refreshButton.prop('disabled', true)
     $refreshStatus.text('Refreshing…')
     $.ajax({
@@ -64,7 +74,7 @@ $(function () {
       url: '/live/refresh',
       data: { crumb: $('#refresh-crumb').val() },
       success: function (summary: { eventsChanged?: number }) {
-        $refreshStatus.text(`Done - ${summary?.eventsChanged ?? 0} goal(s) updated. Reload to see changes.`)
+        $refreshStatus.text(`Done - ${summary?.eventsChanged ?? 0} goal(s) updated.`)
       },
       error: function () {
         $refreshStatus.text('Refresh failed. Please try again.')
@@ -77,6 +87,19 @@ $(function () {
 
   function setStatus (text: string, badge: string): void {
     $status.text(text).removeClass('badge-secondary badge-success badge-warning badge-danger').addClass(badge)
+  }
+
+  function timeAgo (ts: number): string {
+    const elapsed = Date.now() - ts
+    if (elapsed < 2000) { return '1s' }
+    if (elapsed < 60000) { return `${Math.floor(elapsed / 1000)}s` }
+    return `${Math.floor(elapsed / 60000)}m`
+  }
+
+  function setLiveStatus (text: string, badge: string, isLive: boolean): void {
+    statusIsLive = isLive
+    const suffix = lastHeartbeatTs ? ` (last hb ${timeAgo(lastHeartbeatTs)})` : ''
+    setStatus(`${text}${suffix}`, badge)
   }
 
   function resultClass (score: LiveScore): string {
@@ -130,7 +153,11 @@ $(function () {
   }
 
   function addToFeed (event: GoalEvent, prepend: boolean): void {
-    const scorer = event.potentialGoalFor?.player || event.scorer?.name || 'Unknown'
+    const scorer = event.potentialGoalFor
+      ? event.potentialGoalFor.player
+      : event.potentialConcedingFor
+        ? `${event.potentialConcedingFor.team} conceded`
+        : event.scorer?.name || 'Unknown'
     const manager = event.potentialGoalFor?.manager || event.potentialConcedingFor?.manager || ''
     const minute = event.minute ? `${event.minute}'` : ''
     const dateMinute = [formatEventDate(event), minute].filter(Boolean).join(' ')
@@ -179,6 +206,12 @@ $(function () {
     return true
   }
 
+  function recordTimestamp (event: GoalEvent): void {
+    if (event.utcTimestamp && (!lastEventTimestamp || event.utcTimestamp > lastEventTimestamp)) {
+      lastEventTimestamp = event.utcTimestamp
+    }
+  }
+
   function seedFeed (): void {
     if (!historyUrl) { return }
 
@@ -187,44 +220,104 @@ $(function () {
       for (const event of (data?.events || []).filter(isMatched)) {
         if (!event.id || countedEventIds.has(event.id)) { continue }
         countedEventIds.add(event.id)
+        recordTimestamp(event)
         addToFeed(event, false)
       }
     })
   }
+
+  // On reconnect, replay any goals missed while the stream was down or stalled.
+  function fetchMissedEvents (): void {
+    if (!historyUrl || !lastEventTimestamp) { return }
+
+    $.getJSON(historyUrl).done(function (data: { events?: GoalEvent[] }) {
+      const missed = (data?.events || [])
+        .filter(isMatched)
+        .filter(event => event.id && !countedEventIds.has(event.id) && event.utcTimestamp && event.utcTimestamp > lastEventTimestamp!)
+        .reverse()
+
+      let changed = false
+      for (const event of missed) {
+        if (!applyGoal(event)) { continue }
+        addToFeed(event, true)
+        changed = true
+      }
+
+      if (changed) { renderScores() }
+    })
+  }
+
+  function pollSummary (): void {
+    $.getJSON('/live/summary').done(function (data: { gameweekId?: number | null; scores?: LiveScore[] }) {
+      if ((data?.gameweekId ?? null) !== initialGameweekId) {
+        window.location.reload()
+        return
+      }
+
+      scores.clear()
+      for (const score of (data?.scores || [])) {
+        scores.set(score.managerId, score)
+      }
+      renderScores()
+    })
+  }
+
+  function connect (): void {
+    setLiveStatus('Connecting', 'badge-secondary', false)
+
+    if (!source) {
+      seedFeed()
+    } else {
+      fetchMissedEvents()
+    }
+
+    source = new EventSource(streamUrl)
+
+    source.addEventListener('connected', function () {
+      retryDelay = 1000
+      setLiveStatus('Live', 'badge-success', true)
+    })
+
+    source.addEventListener('heartbeat', function () {
+      lastHeartbeatTs = Date.now()
+      setLiveStatus('Live', 'badge-success', true)
+    })
+
+    source.addEventListener('goal', function (e: MessageEvent) {
+      let event: GoalEvent
+      try {
+        event = JSON.parse(e.data)
+      } catch {
+        return
+      }
+
+      recordTimestamp(event)
+      if (!applyGoal(event)) { return }
+
+      renderScores()
+      addToFeed(event, true)
+    })
+
+    // EventSource retries on its own, but we manage reconnection manually so we can
+    // back off and replay missed events once the stream comes back.
+    source.addEventListener('error', function () {
+      setLiveStatus('Reconnecting', 'badge-warning', false)
+      source?.close()
+      setTimeout(connect, retryDelay)
+      retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY_MS)
+    })
+  }
+
+  setInterval(pollSummary, POLL_INTERVAL_MS)
+
+  setInterval(function () {
+    if (statusIsLive) { setLiveStatus('Live', 'badge-success', true) }
+  }, HEARTBEAT_DISPLAY_INTERVAL_MS)
 
   if (!streamUrl) {
     setStatus('Unavailable', 'badge-warning')
     return
   }
 
-  seedFeed()
-
-  const source = new EventSource(streamUrl)
-
-  source.addEventListener('connected', function () {
-    setStatus('Live', 'badge-success')
-  })
-
-  source.addEventListener('goal', function (e: MessageEvent) {
-    let event: GoalEvent
-    try {
-      event = JSON.parse(e.data)
-    } catch {
-      return
-    }
-
-    if (!applyGoal(event)) { return }
-
-    renderScores()
-    addToFeed(event, true)
-  })
-
-  source.onerror = function () {
-    // EventSource retries on its own, so only report a hard failure once it has given up.
-    if (source.readyState === EventSource.CLOSED) {
-      setStatus('Disconnected', 'badge-danger')
-    } else {
-      setStatus('Reconnecting', 'badge-warning')
-    }
-  }
+  connect()
 })

--- a/src/routes/live.ts
+++ b/src/routes/live.ts
@@ -57,28 +57,36 @@ async function getManagers (request: any): Promise<any[]> {
   }
 }
 
+async function buildLiveViewData (request: any): Promise<{ gameweek: any; window: { startDate: Date; endDate: Date } | null; scores: any[]; videprinterAvailable: boolean }> {
+  const videprinterHost = config.get('videprinterHost')
+  const gameweek = await getActiveGameweek(request)
+  const window = getGameweekWindow(gameweek)
+  const [liveSummary, managers] = await Promise.all([
+    getLiveSummary(request, videprinterHost, window),
+    getManagers(request),
+  ])
+
+  const scores = buildLiveScores(managers, liveSummary)
+
+  return { gameweek, window, scores, videprinterAvailable: liveSummary !== null }
+}
+
 const routes: ServerRoute[] = [{
   method: 'GET',
   path: '/live',
   handler: async (request, h) => {
     const videprinterHost = config.get('videprinterHost')
-    const gameweek = await getActiveGameweek(request)
-    const window = getGameweekWindow(gameweek)
-    const [liveSummary, managers] = await Promise.all([
-      getLiveSummary(request, videprinterHost, window),
-      getManagers(request),
-    ])
-
-    const scores = buildLiveScores(managers, liveSummary)
+    const { gameweek, window, scores, videprinterAvailable } = await buildLiveViewData(request)
     const historyParams = window ? `&from=${window.startDate.toISOString()}&to=${window.endDate.toISOString()}` : ''
 
     return h.view('live', {
       gameweek,
       scores,
-      videprinterAvailable: liveSummary !== null,
+      videprinterAvailable,
       liveDataJson: toJsonIsland({
         streamUrl: `${videprinterHost}/videprinter/stream`,
         historyUrl: `${videprinterHost}/videprinter/history?limit=200${historyParams}`,
+        gameweekId: gameweek?.gameweekId ?? null,
         scores,
       }),
     })
@@ -97,6 +105,13 @@ const routes: ServerRoute[] = [{
       request.log(['warn', 'videprinter'], { msg: 'Failed to trigger goal rematch', err: err?.message })
       return boom.badGateway('Unable to reach videprinter service')
     }
+  },
+}, {
+  method: 'GET',
+  path: '/live/summary',
+  handler: async (request, h) => {
+    const { gameweek, scores, videprinterAvailable } = await buildLiveViewData(request)
+    return h.response({ gameweekId: gameweek?.gameweekId ?? null, scores, videprinterAvailable })
   },
 }]
 

--- a/src/views/live.njk
+++ b/src/views/live.njk
@@ -16,7 +16,7 @@
 {% if auth.isAdmin %}
 <div class="mb-3">
   <input type="hidden" id="refresh-crumb" value="{{crumb}}"/>
-  <button id="refresh-goals" type="button" class="btn btn-sm btn-outline-dark">Refresh goals</button>
+  <button id="refresh-goals" type="button" class="btn btn-sm btn-danger" data-toggle="modal" data-target="#refresh-confirm">Refresh goals</button>
   <span id="refresh-status" class="text-muted small ml-2"></span>
 </div>
 {% endif %}
@@ -49,6 +49,27 @@
 </div>
 
 <p class="text-muted small">Scores update automatically every few minutes.</p>
+
+{% if auth.isAdmin %}
+<div class="modal fade" id="refresh-confirm" role="dialog" data-backdrop="false">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Refresh goals</h5>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p>Re-matches all goals scored so far this gameweek against the current teamsheets.</p>
+        <p>This page will pick up the corrected scores automatically within about a minute - it does not reload for you.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" id="refresh-confirm-btn" data-dismiss="modal" class="btn btn-danger">Confirm</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
 
 <script id="live-data" type="application/json">{{ liveDataJson | safe }}</script>
 <script src="{{ asset('javascripts/live.js') }}"></script>

--- a/test/integration/live-route.test.ts
+++ b/test/integration/live-route.test.ts
@@ -11,6 +11,8 @@ const routes = (await import('../../src/routes/live.ts')).default
 const handler = routes[0]!.handler as any
 const refreshRoute = routes[1]!
 const refreshHandler = refreshRoute.handler as any
+const summaryRoute = routes[2]!
+const summaryHandler = summaryRoute.handler as any
 
 const request = { log: vi.fn() }
 
@@ -74,6 +76,16 @@ describe('live route', () => {
     expect(liveData.historyUrl).toContain('/videprinter/history?limit=200')
     expect(liveData.historyUrl).toContain('from=2026-08-08T00:00:00.000Z')
     expect(liveData.historyUrl).toContain('to=2026-08-14T23:59:59.999Z')
+  })
+
+  test('includes the active gameweek id in the json island for client-side polling', async () => {
+    mockApi()
+    mockWreckGet.mockResolvedValue({ payload: { managers: [] } })
+
+    const { context } = await handler(request, view())
+
+    const liveData = JSON.parse(context.liveDataJson)
+    expect(liveData.gameweekId).toBe(5)
   })
 
   test('omits the history date range when there is no active gameweek', async () => {
@@ -176,5 +188,49 @@ describe('live refresh route', () => {
 
     expect(response.isBoom).toBe(true)
     expect(response.output.statusCode).toBe(502)
+  })
+})
+
+describe('live summary route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('is a public GET route', () => {
+    expect(summaryRoute.method).toBe('GET')
+    expect(summaryRoute.path).toBe('/live/summary')
+    expect(summaryRoute.options).toBeUndefined()
+  })
+
+  test('returns the active gameweek id and current scores', async () => {
+    mockApi()
+    mockWreckGet.mockResolvedValue({
+      payload: {
+        managers: [{ managerId: 2, manager: 'Bob', goals: 2, conceded: 1, scorers: [{ playerId: 9, name: 'Smith, John', goals: 2 }] }],
+      },
+    })
+
+    const response = await summaryHandler(request, view())
+
+    expect(response.source.gameweekId).toBe(5)
+    expect(response.source.videprinterAvailable).toBe(true)
+    expect(response.source.scores[0]).toMatchObject({ manager: 'Bob', goals: 2, conceded: 1 })
+  })
+
+  test('returns a null gameweek id when there is no active gameweek', async () => {
+    mockApi({ gameweeks: [{ ...gameweek, isActive: false }] })
+
+    const response = await summaryHandler(request, view())
+
+    expect(response.source.gameweekId).toBeNull()
+  })
+
+  test('reports videprinterAvailable as false when the videprinter is unreachable', async () => {
+    mockApi()
+    mockWreckGet.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const response = await summaryHandler(request, view())
+
+    expect(response.source.videprinterAvailable).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
Follow-up polish to the live matchday page (#30, #31, #32).

### 1. Page now keeps itself up to date without a manual reload
- The SSE client now listens for the `heartbeat` events the videprinter already emits, showing "Live (last hb Xs)" so a silently stalled connection is visible instead of looking falsely healthy.
- Reconnects are now managed manually (exponential backoff, capped at 15s) and, on reconnect, missed goals are replayed from `/videprinter/history` - modelled directly on the videprinter's own client script.
- A new `GET /live/summary` endpoint is polled every 60s to refresh scores and detect a gameweek rollover; if the active gameweek id changes, the page reloads itself automatically. This also means an admin "Refresh goals" correction now shows up on its own within about a minute, with no manual reload needed.

### 2. Conceded goals no longer look like the manager's player scored
When a manager's team concedes (no `potentialGoalFor`), the feed now shows `"<Team> conceded"` instead of the opposing real-world scorer's name, which previously read like that player had scored *for* the manager.

### 3. Safer "Refresh goals" button
- Restyled to `btn-danger` (red) instead of a neutral outline button.
- Now gated behind a Bootstrap confirmation modal, using the same pattern as the results page's send/delete confirmations, explaining what the action does and that it isn't instant - so admins can't trigger it by accident and understand it won't refresh the page for them.

## Testing
- `npm run test` - 101/101 passing (5 new tests for `GET /live/summary` + the gameweek id now included in the json island)
- `npm run test:lint` - clean
- No existing test infrastructure for client-side scripts (`src/client/javascripts`), so the SSE/heartbeat/backoff/poll logic was verified manually, consistent with prior live-page work.